### PR TITLE
Fix edge case in percentile with little data

### DIFF
--- a/lib/tdigest/tdigest.rb
+++ b/lib/tdigest/tdigest.rb
@@ -102,7 +102,9 @@ module TDigest
           _cumulate(true)
           h = @n * item
           lower, upper = bound_mean_cumn(h)
-          if upper == lower || lower.nil? || upper.nil?
+          if lower.nil? && upper.nil?
+            nil
+          elsif upper == lower || lower.nil? || upper.nil?
             (lower || upper).mean
           elsif h == lower.mean_cumn
             lower.mean
@@ -207,4 +209,3 @@ module TDigest
     end
   end
 end
-

--- a/test/tdigest_test.rb
+++ b/test/tdigest_test.rb
@@ -5,4 +5,11 @@ class TDigestTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::TDigest::VERSION
   end
+
+  def test_percentile_edge_case
+    tdigest = ::TDigest::TDigest.new
+    tdigest.push(60, 100)
+    pct = tdigest.percentile(0.90) # This should not crash
+    assert_equal nil, pct
+  end
 end


### PR DESCRIPTION
Thanks for porting this little library to Ruby :)

Running into a bug with some sample data:

``` ruby
tdigest = ::TDigest::TDigest.new
tdigest.push(60, 100)
tdigest.percentile(0.90) # This crashes
```

Backtrace:

```
  1) Error:
TDigestTest#test_percentile_edge_case:
NoMethodError: undefined method `mean' for nil:NilClass
    /Users/lfittl/Code/tdigest/lib/tdigest/tdigest.rb:108:in `block in percentile'
    /Users/lfittl/Code/tdigest/lib/tdigest/tdigest.rb:98:in `map!'
    /Users/lfittl/Code/tdigest/lib/tdigest/tdigest.rb:98:in `percentile'
    /Users/lfittl/Code/tdigest/test/tdigest_test.rb:12:in `test_percentile_edge_case'
```

Obviously the source data here is part of the problem, but this input is user generated - I mostly care about the fact that it doesn't crash. This fixes it and just returns nil in such cases.
